### PR TITLE
Mujina now support attributes with multiple values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The default Identity Provider configuration is as follows:
 * The Entity ID is "http://mock-idp"
 * It has a user with login "admin" and password "secret" with roles ROLE_USER and ROLE_ADMIN
 * It has a user with login "user" and password "secret" with role ROLE_USER
-* It has the following attributes
+* It has the following attributes. Attributes are always stored as lists. Even when they contain a single value.
     * "urn:mace:dir:attribute-def:uid" is "john.doe"
     * "urn:mace:dir:attribute-def:cn" is "John Doe"
     * "urn:mace:dir:attribute-def:givenName" is "John"
@@ -161,12 +161,12 @@ curl -v -H "Accept: application/json" \
 Setting attribute foo to bar (e.g. urn:mace:dir:attribute-def:foo to bar)
 -------------------------------------------------------
 
-This API is only available on the IDP.
+This API is only available on the IDP. **Note:** An attribute is always a list.
 
 ```bash
 curl -v -H "Accept: application/json" \
         -H "Content-type: application/json" \
-        -X PUT -d '{"value": "bar"}' \
+        -X PUT -d '{"value": ["bar"]}' \
         http://localhost:8080/api/attributes/urn:mace:dir:attribute-def:foo
 ```
 

--- a/mujina-common/src/main/java/nl/surfnet/mujina/model/Attribute.java
+++ b/mujina-common/src/main/java/nl/surfnet/mujina/model/Attribute.java
@@ -16,23 +16,23 @@
 
 package nl.surfnet.mujina.model;
 
-import java.io.Serializable;
-
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+import java.util.List;
 
 @XmlRootElement
 public class Attribute implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  private String value;
+  private List<String> value;
 
-  public String getValue() {
+  public List<String> getValue() {
     return value;
   }
 
   @XmlElement
-  public void setValue(final String value) {
+  public void setValue(final List<String> value) {
     this.value = value;
   }
 }

--- a/mujina-idp/src/main/java/nl/surfnet/mujina/model/IdpConfiguration.java
+++ b/mujina-idp/src/main/java/nl/surfnet/mujina/model/IdpConfiguration.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.Map;
 
 public interface IdpConfiguration extends CommonConfiguration {
-  Map<String, String> getAttributes();
+  Map<String, java.util.List<String>> getAttributes();
 
   Collection<SimpleAuthentication> getUsers();
 

--- a/mujina-idp/src/main/java/nl/surfnet/mujina/model/IdpConfigurationImpl.java
+++ b/mujina-idp/src/main/java/nl/surfnet/mujina/model/IdpConfigurationImpl.java
@@ -17,11 +17,7 @@
 package nl.surfnet.mujina.model;
 
 import java.security.KeyStore;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 import nl.surfnet.spring.security.opensaml.util.KeyStoreUtil;
 
@@ -35,7 +31,7 @@ public class IdpConfigurationImpl extends CommonConfigurationImpl implements Idp
 
   private final static Logger LOGGER = LoggerFactory.getLogger(IdpConfigurationImpl.class);
 
-  private Map<String, String> attributes = new TreeMap<String, String>();
+  private Map<String, List<String>> attributes = new TreeMap<>();
   private Collection<SimpleAuthentication> users = new ArrayList<SimpleAuthentication>();
   private AuthenticationMethod.Method authMethod;
 
@@ -48,15 +44,15 @@ public class IdpConfigurationImpl extends CommonConfigurationImpl implements Idp
     authMethod = AuthenticationMethod.Method.ALL;
     entityId = "http://mock-idp";
     attributes.clear();
-    attributes.put("urn:mace:dir:attribute-def:uid", "john.doe");
-    attributes.put("urn:mace:dir:attribute-def:cn", "John Doe");
-    attributes.put("urn:mace:dir:attribute-def:givenName", "John");
-    attributes.put("urn:mace:dir:attribute-def:sn", "Doe");
-    attributes.put("urn:mace:dir:attribute-def:displayName", "John Doe");
-    attributes.put("urn:mace:dir:attribute-def:mail", "j.doe@example.com");
-    attributes.put("urn:mace:terena.org:attribute-def:schacHomeOrganization", "example.com");
-    attributes.put("urn:mace:dir:attribute-def:eduPersonPrincipalName", "j.doe@example.com");
-    attributes.put("urn:oid:1.3.6.1.4.1.1076.20.100.10.10.1", "guest");
+    putAttribute("urn:mace:dir:attribute-def:uid", "john.doe");
+    putAttribute("urn:mace:dir:attribute-def:cn", "John Doe");
+    putAttribute("urn:mace:dir:attribute-def:givenName", "John");
+    putAttribute("urn:mace:dir:attribute-def:sn", "Doe");
+    putAttribute("urn:mace:dir:attribute-def:displayName", "John Doe");
+    putAttribute("urn:mace:dir:attribute-def:mail", "j.doe@example.com");
+    putAttribute("urn:mace:terena.org:attribute-def:schacHomeOrganization", "example.com");
+    putAttribute("urn:mace:dir:attribute-def:eduPersonPrincipalName", "j.doe@example.com");
+    putAttribute("urn:oid:1.3.6.1.4.1.1076.20.100.10.10.1", "guest");
     try {
       keyStore = KeyStore.getInstance("JKS");
       keyStore.load(null, keystorePassword.toCharArray());
@@ -78,8 +74,12 @@ public class IdpConfigurationImpl extends CommonConfigurationImpl implements Idp
     setSigning(false);
   }
 
+  private void putAttribute(String key, String... values) {
+    this.attributes.put(key, Arrays.asList(values));
+  }
+
   @Override
-  public Map<String, String> getAttributes() {
+  public Map<String, List<String>> getAttributes() {
     return attributes;
   }
 

--- a/mujina-idp/src/main/java/nl/surfnet/mujina/saml/xml/AssertionGenerator.java
+++ b/mujina-idp/src/main/java/nl/surfnet/mujina/saml/xml/AssertionGenerator.java
@@ -17,8 +17,10 @@
 package nl.surfnet.mujina.saml.xml;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import nl.surfnet.mujina.model.AuthenticationMethod;
 import nl.surfnet.mujina.model.IdpConfiguration;
@@ -51,6 +53,8 @@ import org.opensaml.xml.signature.SignatureException;
 import org.opensaml.xml.signature.Signer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.util.Arrays.asList;
 
 public class AssertionGenerator {
   private static final Logger logger = LoggerFactory.getLogger(AssertionGenerator.class);
@@ -105,15 +109,15 @@ public class AssertionGenerator {
     assertion.getAuthnStatements().add(authnStatement);
     assertion.setSubject(subject);
 
-    final Map<String, String> attributes = new HashMap<String, String>();
+    final Map<String, List<String>> attributes = new HashMap<>();
     if (null != attributeJson) {
       attributes.putAll(getAttributesFromCookie(attributeJson));
     } else {
       // use the attributes from the IDP Configuration
       attributes.putAll(idpConfiguration.getAttributes());
       if (idpConfiguration.getAuthentication() == AuthenticationMethod.Method.ALL) {
-        attributes.put("urn:mace:dir:attribute-def:uid", name);
-        attributes.put("urn:mace:dir:attribute-def:displayName", name);
+        attributes.put("urn:mace:dir:attribute-def:uid", asList(name));
+        attributes.put("urn:mace:dir:attribute-def:displayName", asList(name));
       }
     }
 
@@ -127,11 +131,12 @@ public class AssertionGenerator {
     return assertion;
   }
 
-  private Map<String, String> getAttributesFromCookie(String attributeJson) {
+  private Map<String, List<String>> getAttributesFromCookie(String attributeJson) {
     ObjectMapper mapper = new ObjectMapper();
-    Map<String, String> result = null;
+    Map<String, List<String>> result = null;
     try {
-      TypeReference<Map<String, String>> typeReference = new TypeReference<Map<String, String>>() {};
+      TypeReference<Map<String, List<String>>> typeReference = new TypeReference<Map<String, List<String>>>() {
+      };
       result = mapper.readValue(attributeJson, typeReference);
     } catch (JsonParseException e) {
       logger.warn("could not parse json file for IDP attributes", e);

--- a/mujina-idp/src/main/java/nl/surfnet/mujina/saml/xml/AttributeStatementGenerator.java
+++ b/mujina-idp/src/main/java/nl/surfnet/mujina/saml/xml/AttributeStatementGenerator.java
@@ -17,6 +17,7 @@
 package nl.surfnet.mujina.saml.xml;
 
 import java.util.Map;
+import java.util.List;
 
 import org.opensaml.Configuration;
 import org.opensaml.saml2.core.Attribute;
@@ -31,20 +32,22 @@ import org.opensaml.xml.schema.impl.XSStringBuilder;
 public class AttributeStatementGenerator {
   private final XMLObjectBuilderFactory builderFactory = Configuration.getBuilderFactory();
 
-  public AttributeStatement generateAttributeStatement(final Map<String, String> attributes) {
+  public AttributeStatement generateAttributeStatement(final Map<String, List<String>> attributes) {
     AttributeStatementBuilder attributeStatementBuilder = (AttributeStatementBuilder) builderFactory
-        .getBuilder(AttributeStatement.DEFAULT_ELEMENT_NAME);
+      .getBuilder(AttributeStatement.DEFAULT_ELEMENT_NAME);
     AttributeStatement attributeStatement = attributeStatementBuilder.buildObject();
 
     AttributeBuilder attributeBuilder = (AttributeBuilder) builderFactory.getBuilder(Attribute.DEFAULT_ELEMENT_NAME);
     XSStringBuilder stringBuilder = (XSStringBuilder) Configuration.getBuilderFactory().getBuilder(XSString.TYPE_NAME);
 
-    for (Map.Entry<String, String> entry : attributes.entrySet()) {
+    for (Map.Entry<String, List<String>> entry : attributes.entrySet()) {
       Attribute attribute = attributeBuilder.buildObject();
       attribute.setName(entry.getKey());
-      XSString stringValue = stringBuilder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSString.TYPE_NAME);
-      stringValue.setValue(entry.getValue());
-      attribute.getAttributeValues().add(stringValue);
+      for (String value : entry.getValue()) {
+        XSString stringValue = stringBuilder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSString.TYPE_NAME);
+        stringValue.setValue(value);
+        attribute.getAttributeValues().add(stringValue);
+      }
       attributeStatement.getAttributes().add(attribute);
     }
 

--- a/mujina-idp/src/test/java/nl/surfnet/mujina/controllers/tests/IdpRestAPITest.java
+++ b/mujina-idp/src/test/java/nl/surfnet/mujina/controllers/tests/IdpRestAPITest.java
@@ -16,25 +16,9 @@
 
 package nl.surfnet.mujina.controllers.tests;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
-import static nl.surfnet.mujina.model.AuthenticationMethod.Method.*;
-import java.io.IOException;
-import java.util.Collections;
-
-import javax.servlet.ServletException;
-
 import nl.surfnet.mujina.controllers.CommonAPI;
 import nl.surfnet.mujina.controllers.IdentityProviderAPI;
-import nl.surfnet.mujina.model.Attribute;
-import nl.surfnet.mujina.model.AuthenticationMethod;
-import nl.surfnet.mujina.model.Credential;
-import nl.surfnet.mujina.model.EntityID;
-import nl.surfnet.mujina.model.User;
-
-import org.junit.After;
+import nl.surfnet.mujina.model.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,9 +30,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.Assert.*;
+import static nl.surfnet.mujina.model.AuthenticationMethod.Method.USER;
+
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "classpath:applicationContext-idp-config.xml", "classpath:applicationContext-property-mappings.xml",
-    "classpath:applicationContext-spring-security.xml", "classpath:api-servlet.xml", "classpath:test-beans.xml" })
+@ContextConfiguration(locations = {"classpath:applicationContext-idp-config.xml", "classpath:applicationContext-property-mappings.xml",
+  "classpath:applicationContext-spring-security.xml", "classpath:api-servlet.xml", "classpath:test-beans.xml"})
 public class IdpRestAPITest {
 
   public static final String DEFAULT_USER = "admin";
@@ -71,7 +64,7 @@ public class IdpRestAPITest {
   @Test
   public void testSetAttribute() throws IOException, ServletException, MessageEncodingException, XMLParserException, UnmarshallingException {
     final String name = "foo";
-    final String value = "bar";
+    final List<String> value = Arrays.asList("bar");
 
     final Response respBefore = testHelper.doSamlLogin(DEFAULT_USER, DEFAULT_PASSWORD);
     assertFalse(testHelper.responseHasAttribute(name, value, respBefore));
@@ -87,11 +80,11 @@ public class IdpRestAPITest {
 
   @Test
   public void testRemoveAttribute() throws IOException, ServletException, MessageEncodingException, XMLParserException,
-      UnmarshallingException {
+    UnmarshallingException {
     restApiController.setAuthenticationMethod(new AuthenticationMethod(USER.name()));
-    
+
     final String name = "urn:mace:dir:attribute-def:uid";
-    final String value = "john.doe";
+    final List<String> value = Arrays.asList("john.doe");
 
     final Response respBefore = testHelper.doSamlLogin(DEFAULT_USER, DEFAULT_PASSWORD);
     assertTrue(testHelper.responseHasAttribute(name, value, respBefore));
@@ -144,12 +137,12 @@ public class IdpRestAPITest {
 
   @Test
   public void testSetSigningCredential() throws IOException, XMLParserException, ServletException, MessageEncodingException,
-      UnmarshallingException {
+    UnmarshallingException {
     Credential credential = new Credential();
     credential
-        .setCertificate("MIICHzCCAYgCCQD7KMJ17XQa7TANBgkqhkiG9w0BAQUFADBUMQswCQYDVQQGEwJOTDEQMA4GA1UECAwHVXRyZWNodDEQMA4GA1UEBwwHVXRyZWNodDEQMA4GA1UECgwHU3VyZm5ldDEPMA0GA1UECwwGQ29uZXh0MB4XDTEyMDMwODA4NTQyNFoXDTEzMDMwODA4NTQyNFowVDELMAkGA1UEBhMCTkwxEDAOBgNVBAgMB1V0cmVjaHQxEDAOBgNVBAcMB1V0cmVjaHQxEDAOBgNVBAoMB1N1cmZuZXQxDzANBgNVBAsMBkNvbmV4dDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA2slVe459WUDL4RXxJf5h5t5oUbPkPlFZ9lQysSoS3fnFTdCgzA6FzQzGRDcfRj0HnWBdA1YH+LxBjNcBIJ/nBc7Ssu4e4rMO3MSAV5Ouo3MaGgHqVq6dCD47f52b98df6QTAA3C+7sHqOdiQ0UDCAK0C+qP5LtTcmB8QrJhKmV8CAwEAATANBgkqhkiG9w0BAQUFAAOBgQCvPhO0aSbqX7g7IkR79IFVdJ/P7uSlYFtJ9cMxec85cYLmWL1aVgF5ZFFJqC25blyPJu2GRcSxoVwB3ae8sPCECWwqRQA4AHKIjiW5NgrAGYR++ssTOQR8mcAucEBfNaNdlJoy8GdZIhHZNkGlyHfY8kWS3OWkGzhWSsuRCLl78A==");
+      .setCertificate("MIICHzCCAYgCCQD7KMJ17XQa7TANBgkqhkiG9w0BAQUFADBUMQswCQYDVQQGEwJOTDEQMA4GA1UECAwHVXRyZWNodDEQMA4GA1UEBwwHVXRyZWNodDEQMA4GA1UECgwHU3VyZm5ldDEPMA0GA1UECwwGQ29uZXh0MB4XDTEyMDMwODA4NTQyNFoXDTEzMDMwODA4NTQyNFowVDELMAkGA1UEBhMCTkwxEDAOBgNVBAgMB1V0cmVjaHQxEDAOBgNVBAcMB1V0cmVjaHQxEDAOBgNVBAoMB1N1cmZuZXQxDzANBgNVBAsMBkNvbmV4dDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA2slVe459WUDL4RXxJf5h5t5oUbPkPlFZ9lQysSoS3fnFTdCgzA6FzQzGRDcfRj0HnWBdA1YH+LxBjNcBIJ/nBc7Ssu4e4rMO3MSAV5Ouo3MaGgHqVq6dCD47f52b98df6QTAA3C+7sHqOdiQ0UDCAK0C+qP5LtTcmB8QrJhKmV8CAwEAATANBgkqhkiG9w0BAQUFAAOBgQCvPhO0aSbqX7g7IkR79IFVdJ/P7uSlYFtJ9cMxec85cYLmWL1aVgF5ZFFJqC25blyPJu2GRcSxoVwB3ae8sPCECWwqRQA4AHKIjiW5NgrAGYR++ssTOQR8mcAucEBfNaNdlJoy8GdZIhHZNkGlyHfY8kWS3OWkGzhWSsuRCLl78A==");
     credential
-        .setKey("MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBANrJVXuOfVlAy+EV8SX+YebeaFGz5D5RWfZUMrEqEt35xU3QoMwOhc0MxkQ3H0Y9B51gXQNWB/i8QYzXASCf5wXO0rLuHuKzDtzEgFeTrqNzGhoB6launQg+O3+dm/fHX+kEwANwvu7B6jnYkNFAwgCtAvqj+S7U3JgfEKyYSplfAgMBAAECgYBaPvwkyCTKYSD4Co37JxAJJCqRsQtv7SyXoCl8zKcVqwaIz4rUQRVN/Hv3/WjIFzqB3xLe4mjNYBIF31YWt/6ZslaLL5YJIXISrMgDuQzPKL8VqvvsH9XEpi/qSUsVAWa9Vaqqwa8JTPELK8QhHKaXTxGtatEuW1x6kSNXFCoasQJBAPUaYdj9oCDOGTaOaupF0GB6TIgIItpQESY1Dfpn4cvwB0jH8wBJSBVeBqSa6dg4RI5ydD3J82xlF7NrQnvWpYkCQQDkg26KzQckoJ39HX2gYS4olSeQDAyIDzeCMkj7McDhigy0cL6k9nOQrKlq6V3vkBISTRg7JceJ4z3QE00edXWnAkEAoggv2WBJxIYbOurJmVhP2gffoiomyEYYIDcAp6KXLdffKOkuJulLIv0GzTiwEMWZ5MWbPOHN78Gg+naU/AM5aQJBALfbsANpt4eW28ceBUgXKMZqS+ywZRzL8YOF5gaGH4TYSCSeWiXsTUtoQN/OaFAqAQBMm2Rrn0KoXcGe5fvN0h0CQQDgNLxVcByrVgmRmTPTwLhSfIveOqE6jBlQ8o0KyoQl4zCSDDtMEb9NEFxxvI7NNjgdZh1RKrzZ5JCAUQcdrEQJ");
+      .setKey("MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBANrJVXuOfVlAy+EV8SX+YebeaFGz5D5RWfZUMrEqEt35xU3QoMwOhc0MxkQ3H0Y9B51gXQNWB/i8QYzXASCf5wXO0rLuHuKzDtzEgFeTrqNzGhoB6launQg+O3+dm/fHX+kEwANwvu7B6jnYkNFAwgCtAvqj+S7U3JgfEKyYSplfAgMBAAECgYBaPvwkyCTKYSD4Co37JxAJJCqRsQtv7SyXoCl8zKcVqwaIz4rUQRVN/Hv3/WjIFzqB3xLe4mjNYBIF31YWt/6ZslaLL5YJIXISrMgDuQzPKL8VqvvsH9XEpi/qSUsVAWa9Vaqqwa8JTPELK8QhHKaXTxGtatEuW1x6kSNXFCoasQJBAPUaYdj9oCDOGTaOaupF0GB6TIgIItpQESY1Dfpn4cvwB0jH8wBJSBVeBqSa6dg4RI5ydD3J82xlF7NrQnvWpYkCQQDkg26KzQckoJ39HX2gYS4olSeQDAyIDzeCMkj7McDhigy0cL6k9nOQrKlq6V3vkBISTRg7JceJ4z3QE00edXWnAkEAoggv2WBJxIYbOurJmVhP2gffoiomyEYYIDcAp6KXLdffKOkuJulLIv0GzTiwEMWZ5MWbPOHN78Gg+naU/AM5aQJBALfbsANpt4eW28ceBUgXKMZqS+ywZRzL8YOF5gaGH4TYSCSeWiXsTUtoQN/OaFAqAQBMm2Rrn0KoXcGe5fvN0h0CQQDgNLxVcByrVgmRmTPTwLhSfIveOqE6jBlQ8o0KyoQl4zCSDDtMEb9NEFxxvI7NNjgdZh1RKrzZ5JCAUQcdrEQJ");
 
     commonAPI.setSigningCredential(credential);
 
@@ -160,8 +153,8 @@ public class IdpRestAPITest {
 
   @Test
   public void testSetAuthentication() throws IOException, XMLParserException, ServletException, MessageEncodingException,
-      UnmarshallingException {
+    UnmarshallingException {
     final Response response = testHelper.doSamlLogin("jaapie", "asdlkfjbdiufv");
-    assertTrue(testHelper.responseHasAttribute("urn:mace:dir:attribute-def:uid", "jaapie", response));
+    assertTrue(testHelper.responseHasAttribute("urn:mace:dir:attribute-def:uid", Arrays.asList("jaapie"), response));
   }
 }

--- a/mujina-idp/src/test/java/nl/surfnet/mujina/controllers/tests/TestHelper.java
+++ b/mujina-idp/src/test/java/nl/surfnet/mujina/controllers/tests/TestHelper.java
@@ -67,11 +67,11 @@ public class TestHelper {
 
   private String protocolBinding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
 
-  public boolean responseHasAttribute(final String name, final String value, final Response resp) {
+  public boolean responseHasAttribute(final String name, final List<String> value, final Response resp) {
         final List<org.opensaml.saml2.core.Attribute> attributes = resp.getAssertions().get(0).getAttributeStatements().get(0).getAttributes();
         for (org.opensaml.saml2.core.Attribute attribute : attributes) {
             if (name.equals(attribute.getName())) {
-                assertTrue(value.equals(attribute.getAttributeValues().get(0).getDOM().getTextContent()));
+                assertTrue(value.contains(attribute.getAttributeValues().get(0).getDOM().getTextContent()));
                 return true;
             }
         }


### PR DESCRIPTION
As per spec attributes should be able to contain multiple values. E.g.

"urn:mace:dir:attribute-def:eduPersonEntitlement": [
  "urn:mace:terena.org:tcs:personal-user",
  "urn:mace:terena.org:tcs:personal-admin"
]

This changes the API in such a way that from now on you ALWAYS need to
PUT attributes in an array as follows {"value": ["value1"]}.
