### PR TITLE
Added support for bulk insert of attributes.

### DIFF
--- a/mujina-idp/src/main/java/nl/surfnet/mujina/controllers/IdentityProviderAPI.java
+++ b/mujina-idp/src/main/java/nl/surfnet/mujina/controllers/IdentityProviderAPI.java
@@ -18,13 +18,9 @@ package nl.surfnet.mujina.controllers;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
-import nl.surfnet.mujina.model.Attribute;
-import nl.surfnet.mujina.model.AuthenticationMethod;
-import nl.surfnet.mujina.model.IdpConfiguration;
-import nl.surfnet.mujina.model.SimpleAuthentication;
-import nl.surfnet.mujina.model.User;
-import nl.surfnet.mujina.model.AcsEndpoint;
+import nl.surfnet.mujina.model.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +46,18 @@ public class IdentityProviderAPI {
   @Autowired
   public IdentityProviderAPI(final IdpConfiguration configuration) {
     this.configuration = configuration;
+  }
+
+  @RequestMapping(value = { "/attributes" }, method = RequestMethod.PUT)
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @ResponseBody
+  public void setAttributes(@RequestBody AttributesMap attribues) {
+    log.debug("Request to replace all attributes");
+    configuration.getAttributes().clear();
+    for(String name : attribues.keySet()) {
+      Attribute attribute = attribues.get(name);
+      configuration.getAttributes().put(name, attribute.getValue());
+    }
   }
 
   @RequestMapping(value = { "/attributes/{name:.+}" }, method = RequestMethod.PUT)

--- a/mujina-idp/src/main/java/nl/surfnet/mujina/model/AttributesMap.java
+++ b/mujina-idp/src/main/java/nl/surfnet/mujina/model/AttributesMap.java
@@ -1,0 +1,6 @@
+package nl.surfnet.mujina.model;
+
+import java.util.HashMap;
+
+// workaround for this: http://stackoverflow.com/a/24318963
+public class AttributesMap extends HashMap<String, Attribute> {}

--- a/mujina-idp/src/test/java/nl/surfnet/mujina/controllers/tests/IdpRestAPITest.java
+++ b/mujina-idp/src/test/java/nl/surfnet/mujina/controllers/tests/IdpRestAPITest.java
@@ -32,9 +32,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static junit.framework.Assert.*;
 import static nl.surfnet.mujina.model.AuthenticationMethod.Method.USER;
@@ -59,6 +57,43 @@ public class IdpRestAPITest {
   @Before
   public void reset() {
     commonAPI.reset();
+  }
+
+  @Test
+  public void testSetAttributes() throws IOException, ServletException, MessageEncodingException, XMLParserException, UnmarshallingException {
+    final String fooName = "foo";
+    final List<String> fooValue = Arrays.asList("fooVal");
+
+    final String barName = "bar";
+    final List<String> barValue = Arrays.asList("barVal");
+
+    final String name = "urn:mace:dir:attribute-def:uid";
+    final List<String> value = Arrays.asList("john.doe");
+
+    restApiController.setAuthenticationMethod(new AuthenticationMethod(USER.name()));
+
+    final Response respBefore = testHelper.doSamlLogin(DEFAULT_USER, DEFAULT_PASSWORD);
+    assertFalse(testHelper.responseHasAttribute(fooName, fooValue, respBefore));
+    assertTrue(testHelper.responseHasAttribute(name, value, respBefore));
+
+    final Attribute fooAttr = new Attribute();
+    fooAttr.setValue(fooValue);
+
+    final Attribute barAttr = new Attribute();
+    barAttr.setValue(barValue);
+
+    AttributesMap attributes = new AttributesMap();
+    attributes.put(fooName, fooAttr);
+    attributes.put(barName, barAttr);
+
+    restApiController.setAttributes(attributes);
+
+    final Response respAfter = testHelper.doSamlLogin(DEFAULT_USER, DEFAULT_PASSWORD);
+    assertTrue(testHelper.responseHasAttribute(fooName, fooValue, respAfter));
+    assertTrue(testHelper.responseHasAttribute(barName, barValue, respAfter));
+
+    // Make sure that the old attributes are removed
+    assertFalse(testHelper.responseHasAttribute(name, value, respAfter));
   }
 
   @Test


### PR DESCRIPTION
In order to make it more convenient to configure all the attributes I added an extra PUT method to `/api/attributes`. It will clear all existing attributes and replace them with new ones.
When I added the parameter to the REST controller I ran into a JSON issue when deserializing a `Map<String, Attribute>`, this was worked around by adding another class, called `AttributesMap extends HashMap<String, Attribute>`, as per this solution on SO: http://stackoverflow.com/a/24318963. According to the SO answer an alternative to this workaround would be to upgrade Spring to v.4.

