### PR TITLE
Use the current port rather than hardcoding 8080

### DIFF
--- a/mujina-idp/src/main/java/mujina/idp/MetadataController.java
+++ b/mujina-idp/src/main/java/mujina/idp/MetadataController.java
@@ -24,6 +24,7 @@ import org.opensaml.xml.signature.SignatureException;
 import org.opensaml.xml.signature.Signer;
 import org.opensaml.xml.util.XMLHelper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.security.saml.key.KeyManager;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -44,6 +45,9 @@ public class MetadataController {
 
   @Autowired
   private IdpConfiguration idpConfiguration;
+
+  @Autowired
+  Environment environment;
 
   @RequestMapping(method = RequestMethod.GET, value = "/metadata", produces = "application/xml")
   public String metadata() throws SecurityException, ParserConfigurationException, SignatureException, MarshallingException, TransformerException {
@@ -72,8 +76,10 @@ public class MetadataController {
 
     idpssoDescriptor.addSupportedProtocol(SAMLConstants.SAML20P_NS);
 
+    String localPort = environment.getProperty("local.server.port");
+    
     SingleSignOnService singleSignOnService = buildSAMLObject(SingleSignOnService.class, SingleSignOnService.DEFAULT_ELEMENT_NAME);
-    singleSignOnService.setLocation("http://localhost:8080/SingleSignOnService");
+    singleSignOnService.setLocation("http://localhost:" + localPort + "/SingleSignOnService");
     singleSignOnService.setBinding(SAMLConstants.SAML2_REDIRECT_BINDING_URI);
 
     idpssoDescriptor.getSingleSignOnServices().add(singleSignOnService);

--- a/mujina-idp/src/test/java/mujina/idp/MetadataControllerTest.java
+++ b/mujina-idp/src/test/java/mujina/idp/MetadataControllerTest.java
@@ -22,7 +22,7 @@ public class MetadataControllerTest extends AbstractIntegrationTest {
       .statusCode(SC_OK)
       .body(
         "EntityDescriptor.IDPSSODescriptor.SingleSignOnService.@Location",
-        equalTo("http://localhost:8080/SingleSignOnService"));
+        equalTo("http://localhost:" + serverPort + "/SingleSignOnService"));
   }
 
 }


### PR DESCRIPTION
I initially wanted to use @LocalServerPort like AbstractIntegrationTest
does, but got execeptions from Spring. This approach is based
on http://stackoverflow.com/a/36391145/797

Fixes #19