### PR TITLE
Do not send SubjectConfirmationData Address= with URL

### DIFF
--- a/mujina-common/src/main/java/mujina/saml/SAMLBuilder.java
+++ b/mujina-common/src/main/java/mujina/saml/SAMLBuilder.java
@@ -57,7 +57,6 @@ public class SAMLBuilder {
     subjectConfirmationData.setRecipient(recipient);
     subjectConfirmationData.setInResponseTo(inResponseTo);
     subjectConfirmationData.setNotOnOrAfter(new DateTime().plusMinutes(8 * 60));
-    subjectConfirmationData.setAddress(recipient);
 
     subjectConfirmation.setSubjectConfirmationData(subjectConfirmationData);
 

--- a/mujina-sp/src/test/resources/saml_response.xml
+++ b/mujina-sp/src/test/resources/saml_response.xml
@@ -33,8 +33,7 @@
     <saml2:Subject>
       <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">admin</saml2:NameID>
       <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
-        <saml2:SubjectConfirmationData Address="http://localhost:9090/saml/SSO"
-                                       InResponseTo="a1fef459164dc0ge323e4564ic56g1"
+        <saml2:SubjectConfirmationData InResponseTo="a1fef459164dc0ge323e4564ic56g1"
                                        NotOnOrAfter="2017-03-29T15:45:32.879Z"
                                        Recipient="http://localhost:9090/saml/SSO"/>
       </saml2:SubjectConfirmation>


### PR DESCRIPTION
Before, Mujina would send the following SubjectConfirmationData:
```xml
 <saml2:SubjectConfirmationData Address="https://engine.example.org/authentication/sp/consume-assertion"
```

The Address attribute is in SAML 2.0 core more or less defined to be
an IP-address (or at least something a session can be "bound" to).
This being an URL trips some very strict libraries.

IP-address binding is not a feature that is useful in Mujina (or in
general, if you ask me). Likely best just not to send it at all.