### PR TITLE
Upgrade spring boot and spring-security-saml

### DIFF
--- a/mujina-common/src/main/java/mujina/api/ErrorController.java
+++ b/mujina-common/src/main/java/mujina/api/ErrorController.java
@@ -1,19 +1,18 @@
 package mujina.api;
 
-import org.springframework.boot.autoconfigure.web.ErrorAttributes;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.context.request.ServletWebRequest;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
 
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
-public class ErrorController implements org.springframework.boot.autoconfigure.web.ErrorController {
+public class ErrorController implements org.springframework.boot.web.servlet.error.ErrorController {
 
   private final ErrorAttributes errorAttributes;
 
@@ -29,8 +28,8 @@ public class ErrorController implements org.springframework.boot.autoconfigure.w
 
   @RequestMapping
   public ResponseEntity<Map<String, Object>> error(HttpServletRequest aRequest) {
-    RequestAttributes requestAttributes = new ServletRequestAttributes(aRequest);
-    Map<String, Object> result = this.errorAttributes.getErrorAttributes(requestAttributes, false);
+    ServletWebRequest webRequest = new ServletWebRequest(aRequest);
+    Map<String, Object> result = this.errorAttributes.getErrorAttributes(webRequest, false);
 
     HttpStatus statusCode = INTERNAL_SERVER_ERROR;
     Object status = result.get("status");

--- a/mujina-idp/pom.xml
+++ b/mujina-idp/pom.xml
@@ -63,12 +63,10 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.5</version>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.0.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/mujina-idp/src/main/java/mujina/MujinaIdpApplication.java
+++ b/mujina-idp/src/main/java/mujina/MujinaIdpApplication.java
@@ -1,14 +1,9 @@
 package mujina;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.actuate.autoconfigure.MetricFilterAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.TraceWebFilterAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(exclude = {
-  TraceWebFilterAutoConfiguration.class,
-  MetricFilterAutoConfiguration.class
-})
+@SpringBootApplication()
 public class MujinaIdpApplication {
 
   public static void main(String[] args) {

--- a/mujina-idp/src/main/java/mujina/api/IdpErrorController.java
+++ b/mujina-idp/src/main/java/mujina/api/IdpErrorController.java
@@ -1,7 +1,7 @@
 package mujina.api;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.web.ErrorAttributes;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/mujina-idp/src/main/java/mujina/idp/WebSecurityConfigurer.java
+++ b/mujina-idp/src/main/java/mujina/idp/WebSecurityConfigurer.java
@@ -14,12 +14,9 @@ import org.opensaml.xml.parse.StaticBasicParserPool;
 import org.opensaml.xml.parse.XMLParserException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
-import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -30,7 +27,7 @@ import org.springframework.security.saml.key.JKSKeyManager;
 import org.springframework.security.saml.util.VelocityFactory;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
@@ -45,10 +42,7 @@ import java.util.Collections;
 
 @Configuration
 @EnableWebSecurity
-public class WebSecurityConfigurer extends WebMvcConfigurerAdapter {
-
-  @Autowired
-  private Environment environment;
+public class WebSecurityConfigurer implements WebMvcConfigurer {
 
   @Bean
   @Autowired
@@ -106,7 +100,6 @@ public class WebSecurityConfigurer extends WebMvcConfigurerAdapter {
   }
 
   @Configuration
-  @Order(SecurityProperties.ACCESS_OVERRIDE_ORDER)
   protected static class ApplicationSecurity extends WebSecurityConfigurerAdapter {
 
     @Autowired

--- a/mujina-idp/src/main/resources/application.yml
+++ b/mujina-idp/src/main/resources/application.yml
@@ -5,13 +5,14 @@ logging:
 server:
   # The port to where this Spring Boot application listens to. e.g. http://localhost:{{ springapp_tcpport }}
   port: 8080
-  # The context path of the server. You can skip this value in the overriding application.yml on the classpath
-  contextPath:
-  session:
-    # 8 hours before we time-out
-    timeout: 28800
-    cookie:
-      secure: false
+  servlet:
+    # The context path of the server. You can skip this value in the overriding application.yml on the classpath
+    context-path:
+    session:
+      # 8 hours before we time-out
+      timeout: 28800
+      cookie:
+        secure: false
 
 # Identity Provider
 idp:
@@ -40,18 +41,21 @@ spring:
   velocity:
     check-template-location: False
 
-# We disable all endpoints except health for the load-balancer and info for git information.
-endpoints:
-  enabled: false
-  jmx:
-    enabled: false
-  health:
-    enabled: true
-  info:
-    enabled: true
-
 # used by the git plugin
 info:
   build:
     artifact: "@project.artifactId@"
     version: "@project.version@"
+    
+# We disable all endpoints except health for the load-balancer and info for git information.
+management:
+  endpoints:
+    enabled-by-default: false
+    jmx:
+      exposure:
+        exclude: '*'
+  endpoint:
+    health:
+      enabled: true
+    info:
+      enabled: true

--- a/mujina-idp/src/test/java/mujina/AbstractIntegrationTest.java
+++ b/mujina-idp/src/test/java/mujina/AbstractIntegrationTest.java
@@ -6,8 +6,8 @@ import mujina.api.IdpConfiguration;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static io.restassured.RestAssured.given;

--- a/mujina-sp/pom.xml
+++ b/mujina-sp/pom.xml
@@ -64,7 +64,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.5</version>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
@@ -75,7 +74,6 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.0.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/mujina-sp/src/main/java/mujina/MujinaSpApplication.java
+++ b/mujina-sp/src/main/java/mujina/MujinaSpApplication.java
@@ -1,14 +1,9 @@
 package mujina;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.actuate.autoconfigure.MetricFilterAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.TraceWebFilterAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(exclude = {
-  TraceWebFilterAutoConfiguration.class,
-  MetricFilterAutoConfiguration.class
-})
+@SpringBootApplication()
 public class MujinaSpApplication {
 
   public static void main(String[] args) {

--- a/mujina-sp/src/main/java/mujina/api/SpErrorController.java
+++ b/mujina-sp/src/main/java/mujina/api/SpErrorController.java
@@ -1,7 +1,7 @@
 package mujina.api;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.web.ErrorAttributes;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/mujina-sp/src/main/java/mujina/sp/SAMLConfig.java
+++ b/mujina-sp/src/main/java/mujina/sp/SAMLConfig.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.saml.SAMLBootstrap;
 import org.springframework.security.saml.context.SAMLMessageContext;
@@ -131,7 +132,7 @@ public class SAMLConfig {
 
   @Bean
   public WebSSOProfileConsumer webSSOprofileConsumer() {
-    WebSSOProfileConsumerImpl webSSOProfileConsumer = environment.acceptsProfiles("test") ?
+    WebSSOProfileConsumerImpl webSSOProfileConsumer = environment.acceptsProfiles(Profiles.of("test")) ?
       new WebSSOProfileConsumerImpl() {
         @Override
         @SuppressWarnings("unchecked")

--- a/mujina-sp/src/main/resources/application.yml
+++ b/mujina-sp/src/main/resources/application.yml
@@ -5,13 +5,14 @@ logging:
 server:
   # The port to where this Spring Boot application listens to. e.g. http://localhost:{{ springapp_tcpport }}
   port: 9090
-  # The context path of the server. You can skip this value in the overriding application.yml on the classpath
-  contextPath:
-  session:
-    # 8 hours before we time-out
-    timeout: 28800
-    cookie:
-      secure: false
+  servlet:
+    # The context path of the server. You can skip this value in the overriding application.yml on the classpath
+    context-path:
+    session:
+      # 8 hours before we time-out
+      timeout: 28800
+      cookie:
+        secure: false
 
 sp:
   # base url
@@ -42,18 +43,21 @@ spring:
   velocity:
     check-template-location: False
 
-# We disable all endpoints except health for the load-balancer and info for git information.
-endpoints:
-  enabled: false
-  jmx:
-    enabled: false
-  health:
-    enabled: true
-  info:
-    enabled: true
-
 # used by the git plugin
 info:
   build:
     artifact: "@project.artifactId@"
     version: "@project.version@"
+    
+# We disable all endpoints except health for the load-balancer and info for git information.
+management:
+  endpoints:
+    enabled-by-default: false
+    jmx:
+      exposure:
+        exclude: '*'
+  endpoint:
+    health:
+      enabled: true
+    info:
+      enabled: true

--- a/mujina-sp/src/test/java/mujina/AbstractIntegrationTest.java
+++ b/mujina-sp/src/test/java/mujina/AbstractIntegrationTest.java
@@ -7,8 +7,8 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.junit4.SpringRunner;
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,13 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <httpclient.version>4.5.6</httpclient.version>
-    <spring-security-saml2-core.version>1.0.4.RELEASE</spring-security-saml2-core.version>
+    <spring-security-saml2-core.version>1.0.9.RELEASE</spring-security-saml2-core.version>
   </properties>
 
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.18.RELEASE</version>
+    <version>2.1.6.RELEASE</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
- Spring Boot has been upgraded to version 2.1.6.RELEASE
- Spring Security SAML has been upgraded to 1.0.9.RELEASE
- I also removed the versions from rest-assured and commons-lang dependencies as the version for those are inherited from the spring boot parent pom