### PR TITLE
Avoid hardcoding localhost in IDP metadata

### DIFF
--- a/mujina-idp/src/main/java/mujina/idp/MetadataController.java
+++ b/mujina-idp/src/main/java/mujina/idp/MetadataController.java
@@ -25,6 +25,7 @@ import org.opensaml.xml.signature.SignatureException;
 import org.opensaml.xml.signature.Signer;
 import org.opensaml.xml.util.XMLHelper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.security.saml.key.KeyManager;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,6 +35,10 @@ import org.w3c.dom.Element;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
 
 import static mujina.saml.SAMLBuilder.buildSAMLObject;
 
@@ -49,8 +54,9 @@ public class MetadataController {
   @Autowired
   Environment environment;
 
+  @Autowired
   @RequestMapping(method = RequestMethod.GET, value = "/metadata", produces = "application/xml")
-  public String metadata() throws SecurityException, ParserConfigurationException, SignatureException, MarshallingException, TransformerException {
+  public String metadata(@Value("${idp.base_url}") String idpBaseUrl) throws SecurityException, ParserConfigurationException, SignatureException, MarshallingException, TransformerException {
     EntityDescriptor entityDescriptor = buildSAMLObject(EntityDescriptor.class, EntityDescriptor.DEFAULT_ELEMENT_NAME);
     entityDescriptor.setEntityID(idpConfiguration.getEntityId());
     entityDescriptor.setID(SAMLBuilder.randomSAMLId());
@@ -78,8 +84,9 @@ public class MetadataController {
 
     String localPort = environment.getProperty("local.server.port");
 
+
     SingleSignOnService singleSignOnService = buildSAMLObject(SingleSignOnService.class, SingleSignOnService.DEFAULT_ELEMENT_NAME);
-    singleSignOnService.setLocation("http://localhost:" + localPort + "/SingleSignOnService");
+    singleSignOnService.setLocation(idpBaseUrl + "/SingleSignOnService");
     singleSignOnService.setBinding(SAMLConstants.SAML2_REDIRECT_BINDING_URI);
 
     idpssoDescriptor.getSingleSignOnServices().add(singleSignOnService);

--- a/mujina-idp/src/main/java/mujina/idp/MetadataController.java
+++ b/mujina-idp/src/main/java/mujina/idp/MetadataController.java
@@ -36,10 +36,6 @@ import org.w3c.dom.Element;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URL;
-
 import static mujina.saml.SAMLBuilder.buildSAMLObject;
 
 @RestController

--- a/mujina-idp/src/test/java/mujina/idp/MetadataControllerTest.java
+++ b/mujina-idp/src/test/java/mujina/idp/MetadataControllerTest.java
@@ -22,7 +22,7 @@ public class MetadataControllerTest extends AbstractIntegrationTest {
       .statusCode(SC_OK)
       .body(
         "EntityDescriptor.IDPSSODescriptor.SingleSignOnService.@Location",
-        equalTo("http://localhost:" + serverPort + "/SingleSignOnService"));
+        equalTo("http://localhost:8080/SingleSignOnService"));
   }
 
 }


### PR DESCRIPTION
Not sure if you're interested in the change, but I wanted to be able to set `idp.base_url` to something other than localhost and found the IdP then didn't work.

This change fixes that, though currently it does as a result require that `idp.base_url` be set if the port is anything other than the default. Happy to discuss potential solutions if that's a problem but the change is of interest.