### PR TITLE
Fix the add attribute select in ie 10/11

### DIFF
--- a/mujina-idp/src/main/resources/public/main.js
+++ b/mujina-idp/src/main/resources/public/main.js
@@ -28,8 +28,8 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   document.querySelector(".attribute-select").addEventListener("change", function (e) {
-    var selectedOption = e.target.selectedOptions[0];
-    var val = selectedOption.value;
+    var val = e.target.value;
+    var selectedOption = document.querySelector('option[value="' + val + '"]');
     var text = selectedOption.text;
     var multiplicity = selectedOption.dataset.multiplicity === "true";
     var newElement = document.createElement("li");


### PR DESCRIPTION
Prior to this change, the select did not work because the event handler used the selectedOptions property, which does not work in IE (see: https://caniuse.com/?search=selectedoptions).

This change reworks the code to use the value and select the correct option from there.  All of that code is compatible with IE10/11 and modern browsers.