### PR TITLE
Externalized SAML attribute and default value configuration

### DIFF
--- a/mujina-idp/src/main/java/mujina/api/IdpConfiguration.java
+++ b/mujina-idp/src/main/java/mujina/api/IdpConfiguration.java
@@ -3,6 +3,7 @@ package mujina.api;
 import lombok.Getter;
 import lombok.Setter;
 import mujina.idp.FederatedUserAuthenticationToken;
+import mujina.config.StandardAttributes;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -28,18 +29,22 @@ public class IdpConfiguration extends SharedConfiguration {
   private AuthenticationMethod defaultAuthenticationMethod;
   private final String idpPrivateKey;
   private final String idpCertificate;
+  private final StandardAttributes standardAttributes;
 
   @Autowired
   public IdpConfiguration(JKSKeyManager keyManager,
                           @Value("${idp.entity_id}") String defaultEntityId,
                           @Value("${idp.private_key}") String idpPrivateKey,
                           @Value("${idp.certificate}") String idpCertificate,
-                          @Value("${idp.auth_method}") String authMethod) {
+                          @Value("${idp.auth_method}") String authMethod,
+                          StandardAttributes standardAttributes) {
+
     super(keyManager);
     this.defaultEntityId = defaultEntityId;
     this.idpPrivateKey = idpPrivateKey;
     this.idpCertificate = idpCertificate;
     this.defaultAuthenticationMethod = AuthenticationMethod.valueOf(authMethod);
+    this.standardAttributes = standardAttributes;
     reset();
   }
 
@@ -63,15 +68,13 @@ public class IdpConfiguration extends SharedConfiguration {
   }
 
   private void resetAttributes() {
+    Map<String, String> configuredAttributes = standardAttributes.getAttributes();
+
     attributes.clear();
-    putAttribute("urn:mace:dir:attribute-def:uid", "john.doe");
-    putAttribute("urn:mace:dir:attribute-def:cn", "John Doe");
-    putAttribute("urn:mace:dir:attribute-def:givenName", "John");
-    putAttribute("urn:mace:dir:attribute-def:sn", "Doe");
-    putAttribute("urn:mace:dir:attribute-def:displayName", "John Doe");
-    putAttribute("urn:mace:dir:attribute-def:mail", "j.doe@example.com");
-    putAttribute("urn:mace:terena.org:attribute-def:schacHomeOrganization", "example.com");
-    putAttribute("urn:mace:dir:attribute-def:eduPersonPrincipalName", "j.doe@example.com");
+    for (Map.Entry<String, String> attribute : configuredAttributes.entrySet()) {
+      putAttribute(attribute.getKey(), attribute.getValue());
+    }
+
   }
 
   private void putAttribute(String key, String... values) {

--- a/mujina-idp/src/main/java/mujina/config/StandardAttributes.java
+++ b/mujina-idp/src/main/java/mujina/config/StandardAttributes.java
@@ -1,0 +1,33 @@
+package mujina.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+@ConfigurationProperties(prefix = "idp")
+public class StandardAttributes {
+
+    private Map<String, String> attributes;
+
+    private final Pattern escapedValuePattern = Pattern.compile("\\[(.*)]");
+
+    public void setAttributes(Map<String, String> attributes) {
+        Map<String, String> processedAttributes = new HashMap<>();
+
+        for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+            Matcher matcher = escapedValuePattern.matcher(attribute.getKey());
+            processedAttributes.put(matcher.matches() ? matcher.group(1) : attribute.getKey(), attribute.getValue());
+        }
+
+        this.attributes = processedAttributes;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+}

--- a/mujina-idp/src/main/java/mujina/idp/UserController.java
+++ b/mujina-idp/src/main/java/mujina/idp/UserController.java
@@ -2,7 +2,8 @@ package mujina.idp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -15,12 +16,16 @@ import java.util.Map;
 @Controller
 public class UserController {
 
-  private List<Map<String, String>> samlAttributes;
+  private final List<Map<String, String>> samlAttributes;
 
   @Autowired
   @SuppressWarnings("unchecked")
-  public UserController(ObjectMapper objectMapper) throws IOException {
-    this.samlAttributes = objectMapper.readValue(new ClassPathResource("saml-attributes.json").getInputStream(), List.class);
+  public UserController(ObjectMapper objectMapper,
+                      @Value("${idp.saml_attributes_config_file}") String samlAttributesConfigFile) throws IOException {
+
+    DefaultResourceLoader loader = new DefaultResourceLoader();
+    this.samlAttributes = objectMapper.readValue(
+            loader.getResource(samlAttributesConfigFile).getInputStream(), List.class);
   }
 
   @GetMapping("/")

--- a/mujina-idp/src/main/resources/application.yml
+++ b/mujina-idp/src/main/resources/application.yml
@@ -33,6 +33,18 @@ idp:
   auth_method: ALL
   # Are endpoints compared. If so then pay notice to the base_url when behind a load balancer
   compare_endpoints: true
+  # SAML configuration file. To use an external file, prefix path with "file:".
+  saml_attributes_config_file: classpath:saml-attributes.json
+  # Default attributes and values. Escaped to prevent filtering of the ':' character
+  attributes:
+    [urn:mace:dir:attribute-def:uid]: "john.doe"
+    [urn:mace:dir:attribute-def:cn]: "John Doe"
+    [urn:mace:dir:attribute-def:givenName]: "John"
+    [urn:mace:dir:attribute-def:sn]: "Doe"
+    [urn:mace:dir:attribute-def:displayName]: "John Doe"
+    [urn:mace:dir:attribute-def:mail]: "j.doe@example.com"
+    [urn:mace:terena.org:attribute-def:schacHomeOrganization]: "example.com"
+    [urn:mace:dir:attribute-def:eduPersonPrincipalName]: "j.doe@example.com"
 
 spring:
   mvc:


### PR DESCRIPTION
For the purpose of eternalizing configuration, this PR has been submitted. With this PR two changes are introduced:
- The location of the saml-attributes.json file is no longer hardcoded but added to application.yml, in which either the prefix classpath: can be used for using the bundled version of the configuration (default) or the configuration can be prefixed with "file:" to use an external configuration
- Default values for the attributes have been moved from being hardcoded in the IdpConfiguration class to configuration in the application.yml (which is read by the class StandardAttributes). 

With these changes, (stock)Mujina can be easily used when using a different attribute context. 