### PR TITLE
feat: bring back configurable validity of metadata entity descriptor

### DIFF
--- a/mujina-idp/src/main/java/mujina/idp/MetadataController.java
+++ b/mujina-idp/src/main/java/mujina/idp/MetadataController.java
@@ -1,5 +1,6 @@
 package mujina.idp;
 
+import java.util.Optional;
 import mujina.api.IdpConfiguration;
 import mujina.saml.SAMLBuilder;
 import org.joda.time.DateTime;
@@ -37,6 +38,7 @@ import static mujina.saml.SAMLBuilder.signAssertion;
 @RestController
 public class MetadataController {
 
+
     @Autowired
     private KeyManager keyManager;
 
@@ -49,13 +51,17 @@ public class MetadataController {
     @Value("${idp.saml_binding}")
     private String samlBinding;
 
+    @Value("${idp.entity_descriptor_valid_until_millis:#{null}}")
+    private Optional<Integer> entityDescriptorValidUntilMillis;
+
     @Autowired
     @RequestMapping(method = RequestMethod.GET, value = "/metadata", produces = "application/xml")
     public String metadata(@Value("${idp.base_url}") String idpBaseUrl) throws SecurityException, ParserConfigurationException, SignatureException, MarshallingException, TransformerException {
         EntityDescriptor entityDescriptor = buildSAMLObject(EntityDescriptor.class, EntityDescriptor.DEFAULT_ELEMENT_NAME);
         entityDescriptor.setEntityID(idpConfiguration.getEntityId());
         entityDescriptor.setID(SAMLBuilder.randomSAMLId());
-        entityDescriptor.setValidUntil(new DateTime().plusMillis(86400000));
+        entityDescriptorValidUntilMillis.ifPresent(
+            value -> entityDescriptor.setValidUntil(new DateTime().plusMillis(value)));
 
         Signature signature = buildSAMLObject(Signature.class, Signature.DEFAULT_ELEMENT_NAME);
 

--- a/mujina-idp/src/main/resources/application.yml
+++ b/mujina-idp/src/main/resources/application.yml
@@ -17,6 +17,8 @@ secure_cookie: false
 # Identity Provider
 idp:
   entity_id: http://mock-idp
+  # How long the IDP metadata is valid (default 24 hours); set to an empty value for unlimited validity
+  entity_descriptor_valid_until_millis: 86400000
   # base url
   base_url: http://localhost:8080
   # Private key used to sign the SAML response

--- a/mujina-idp/src/test/java/mujina/idp/MetadataControllerTest.java
+++ b/mujina-idp/src/test/java/mujina/idp/MetadataControllerTest.java
@@ -1,6 +1,11 @@
 package mujina.idp;
 
 import mujina.AbstractIntegrationTest;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -14,11 +19,23 @@ public class MetadataControllerTest extends AbstractIntegrationTest {
 
     @Value("${idp.base_url}")
     private String idpBaseUrl;
+    private long fixedSystemTime;
+
+    @Before
+    public void setUp() {
+        fixedSystemTime = System.currentTimeMillis();
+        DateTimeUtils.setCurrentMillisFixed(fixedSystemTime);
+    }
+
+    @After
+    public void tearDown() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
 
     @Test
     public void metadata() throws Exception {
         given()
-                .config(newConfig()
+            .config(newConfig()
                         .xmlConfig(xmlConfig().declareNamespace("md", "urn:oasis:names:tc:SAML:2.0:metadata")))
                 .header("Content-Type", "application/xml")
                 .get("/metadata")
@@ -28,7 +45,10 @@ public class MetadataControllerTest extends AbstractIntegrationTest {
                         "EntityDescriptor.IDPSSODescriptor.SingleSignOnService.@Location",
                         equalTo(idpBaseUrl + "/SingleSignOnService"))
                 .body("EntityDescriptor.IDPSSODescriptor.SingleSignOnService.@Binding",
-                    equalTo("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"));;
+                    equalTo("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"))
+                .body("EntityDescriptor.@validUntil", equalTo(
+                    new DateTime().withZone(DateTimeZone.UTC).plusMillis(86400000)
+                        .toString("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")));
     }
 
 }


### PR DESCRIPTION
Allow configuring `validUntil` attribute value, including omitting the value. Currently the IDP metadata will expire after 24h, which makes testing a bit cumbersome, as our SP will reject an IDP with expired metadata :)